### PR TITLE
Only allow a logged in user to see their own page

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class ErrorsController < ApplicationController
+  def forbidden
+    render status: :forbidden
+  end
+
+  def not_found
+    render status: :not_found
+  end
+
+  def internal_server_error
+    render status: :internal_server_error
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,12 +3,20 @@ class UsersController < ApplicationController
   before_action :set_user, only: [:show]
 
   # GET /users/1 or /users/1.json
-  def show; end
+  def show
+    # Is this the logged in user's own page?
+    @my_page = current_user.id.to_s == @user.id.to_s
+    # Unless this page belongs to the logged in user, return 403 Forbidden.
+    render "errors/forbidden", status: :forbidden, formats: [:html] unless @my_page
+  end
 
   private
 
     # Use callbacks to share common setup or constraints between actions.
     def set_user
       @user = User.find(params[:id])
+    # Do not allow any fishing for what database ids exist. Return 403 Forbidden.
+    rescue ActiveRecord::RecordNotFound
+      render "errors/forbidden", status: :forbidden, formats: [:html]
     end
 end

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,0 +1,2 @@
+<h1>Forbidden</h1>
+<p>You do not have permission to view this page.</p>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,0 +1,2 @@
+<h1>Something went wrong!</h1>
+<p>The ORCID@Princeton development team has been automatically alerted of this error.</p>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,0 +1,2 @@
+<h1>Page not found</h1>
+<p>The page you tried to retrieve was not found.</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,9 @@ module OrcidPrinceton
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
 
+    # Use the errors controller for exceptions
+    config.exceptions_app = routes
+
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,11 @@ Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   mount HealthMonitor::Engine, at: "/"
 
+  # Branded error pages
+  match "/403", to: "errors#forbidden", via: :all
+  match "/404", to: "errors#not_found", via: :all
+  match "/500", to: "errors#internal_server_error", via: :all
+
   resources :users, only: [:show]
 
   get "orcids/:id", to: "orcids#show", as: :orcid_show

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "Errors", type: :request do
+  let(:user) { FactoryBot.create :user }
+
+  describe "GET a non-existent page" do
+    it "returns a not_found error" do
+      login_as user
+      get "/a_non_existent_page"
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "GET a user page without being logged in first" do
+    it "redirects to login" do
+      get "/users/fake_user"
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+
+  describe "a logged in user tries to GET a non existent user" do
+    it "returns status forbidden" do
+      login_as user
+      get "/users/fake_user"
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "a logged in user tries to GET a different user" do
+    let(:user1) { FactoryBot.create :user }
+    let(:user2) { FactoryBot.create :user }
+    it "returns status forbidden" do
+      login_as user1
+      get "/users/#{user2.id}"
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -39,12 +39,11 @@ RSpec.describe "/users", type: :request do
   context "Whan a user is signed in" do
     let(:user) { FactoryBot.create :user }
     before do
-      sign_in user
+      login_as user
     end
 
     describe "GET /show" do
       it "renders a successful response" do
-        user = User.create! valid_attributes
         get user_url(user)
         expect(response).to be_successful
       end

--- a/spec/system/ux_flow_spec.rb
+++ b/spec/system/ux_flow_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 describe "user experience from start to finish", type: :system, js: true do
   context "a user without an orcid on file" do
     let(:user) { FactoryBot.create :user }
+    let(:user2) { FactoryBot.create :user }
     let(:orcid_identifier) { (FactoryBot.build :user_with_orcid).orcid }
     it "walks the user through the process of entering an ORCID and creating a token" do
       login_as user
@@ -23,6 +24,13 @@ describe "user experience from start to finish", type: :system, js: true do
         .skipping(:'color-contrast')
 
       expect(page).to have_content "This application is asking you to add Princeton University"
+
+      # Trying to access the page of another user should be forbidden.
+      visit "/users/#{user2.id}"
+      expect(page).to have_content "Forbidden"
+      expect(page).to be_axe_clean
+        .according_to(:wcag2a, :wcag2aa, :wcag21a, :wcag21aa, :section508)
+        .skipping(:'color-contrast')
     end
   end
 end


### PR DESCRIPTION
Also, implement custom error pages so errors will display in a styled and branded way.

Fixes #66 