### PR TITLE
Allow assets precompile on a capistrano roll back

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -14,3 +14,5 @@ set :deploy_to, "/opt/orcid_princeton"
 
 # Must match `ViteRuby.config.public_output_dir`, which by default is 'vite'
 set :assets_prefix, "vite"
+
+before "deploy:reverted", "deploy:assets:precompile"


### PR DESCRIPTION
@tpendragon pointed out [this issue](https://github.com/https://github.com/capistrano/npm/issues/7) which has a suggested solution. Since we do not run npm:install we run deploy:asset:precompile, which runs yarn install that is what I did in this PR.

refs https://github.com/pulibrary/pdc_describe/pull/1596