### PR TITLE
Ensure the sandbox variable can be set to false in production

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -323,7 +323,7 @@ end
 #  This is intentionally outside of the devise block,
 #  becuase including it inside the devise block did not allow member and sandbox to be passed
 Rails.application.config.middleware.use OmniAuth::Builder do
-  sandbox = Rails.env.development? || Rails.env.staging? || ActiveModel::Type::Boolean.new.cast(ENV["ORCID_SANDBOX"].downcase)
+  sandbox = Rails.env.development? || Rails.env.staging? || ActiveModel::Type::Boolean.new.cast(ENV["ORCID_SANDBOX"]&.downcase)
   callback = "/auth/orcid/callback"
   provider :orcid, ENV["ORCID_CLIENT_ID"], ENV["ORCID_CLIENT_SECRET"], member: true, sandbox:, callback_path: callback
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -323,7 +323,7 @@ end
 #  This is intentionally outside of the devise block,
 #  becuase including it inside the devise block did not allow member and sandbox to be passed
 Rails.application.config.middleware.use OmniAuth::Builder do
-  sandbox = Rails.env.development? || Rails.env.staging? || ActiveModel::Type::Boolean.new.cast(ENV["ORCID_SANDBOX"])
+  sandbox = Rails.env.development? || Rails.env.staging? || ActiveModel::Type::Boolean.new.cast(ENV["ORCID_SANDBOX"].downcase)
   callback = "/auth/orcid/callback"
   provider :orcid, ENV["ORCID_CLIENT_ID"], ENV["ORCID_CLIENT_SECRET"], member: true, sandbox:, callback_path: callback
 end


### PR DESCRIPTION
Even though ENV['ORCID_SANDBOX'] was being set to false in princeton_ansible, the variable was still getting set to true on the production server. I found the reason why documented here: https://stackoverflow.com/questions/36228873/ruby-how-to-convert-a-string-to-boolean

An illustration of the fix, from the rails console on the production server:

> irb(main):008> ENV['ORCID_SANDBOX']
> => "False"
> irb(main):009> ActiveModel::Type::Boolean.new.cast(ENV["ORCID_SANDBOX"]) 
> => true
> irb(main):011> ActiveModel::Type::Boolean.new.cast(ENV["ORCID_SANDBOX"].downcase) 
> => false

Advances #51 