### PR TITLE
Re-apply formatting to token prompt screen

### DIFF
--- a/app/javascript/entrypoints/application.scss
+++ b/app/javascript/entrypoints/application.scss
@@ -329,6 +329,27 @@ p {
   font-family: 'princetonmontidsregular', Arial, sans-serif;
 }
 
+.welcome-section {
+  padding-left: 8rem;
+}
+
+.welcome-section h2 {
+  padding-top: 3rem;
+}
+
+.text-box {
+  width: 60%;
+  margin: 1rem 1.8rem 3rem 2rem;
+}
+
+a[target="_blank"]::after {
+  content: "";width: 11px;height: 11px;margin-left: 4px;background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='currentColor' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z'/%3E%3Cpath fill-rule='evenodd' d='M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z'/%3E%3C/svg%3E");background-position: center;background-repeat: no-repeat;background-size: contain;display: inline-block;
+} 
+
+.orcid-connect .line {
+  width: 60%;
+}
+
 @media (max-width: 810px) {
   #info-section {
     display: flex;


### PR DESCRIPTION
Did the formatting get removed for a reason?  I think the formatting I applied looks closer to the wireframes in #168

View in main
'![Screenshot 2024-07-31 at 8 43 54 AM](https://github.com/user-attachments/assets/5dc2e94b-105c-4d4c-9038-2cc5d18035c9)

Display in this branch and my previous PR. 
![Screenshot 2024-07-31 at 8 42 40 AM](https://github.com/user-attachments/assets/f6de9735-a2e8-4501-bfdb-3ac379d6730b)
