### PR TITLE
Allows a user to revoke ORCiD tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
+.DS_Store
 
 # Used by dotenv library to load environment variables.
 # .env

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,7 @@ class UsersController < ApplicationController
     render "errors/forbidden", status: :forbidden, formats: [:html] unless @my_page
   end
 
+  # POST /users/1/orcid_revoke
   def orcid_revoke
     user = User.find(params[:id])
     user.revoke_active_tokens

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,12 @@ class UsersController < ApplicationController
     render "errors/forbidden", status: :forbidden, formats: [:html] unless @my_page
   end
 
+  def orcid_revoke
+    user = User.find(params[:id])
+    user.revoke_active_tokens
+    redirect_to user_path(user)
+  end
+
   private
 
     # Use callbacks to share common setup or constraints between actions.

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -56,3 +56,14 @@ window.log_plausible_contact_us = function () {
 };
 /* eslint-enable no-console */
 /* eslint-enable no-undef */
+
+window.confirmOrcidRemove = function confirmOrcidRemove(id) {
+  const button = document.getElementById(id);
+  button.onclick = function(event) {
+    const remove = confirm("Are you sure you want to revoke Princeton access to your ORCiD profile?");
+    if(remove !== true) {
+      // cancel the button click
+      event.preventDefault();
+    }
+  };
+}

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -45,6 +45,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 /* eslint-disable no-console */
 /* eslint-disable no-undef */
+/* eslint-disable func-names */
 window.log_plausible_cas_user_login = function () {
   console.log('log_plausible_cas_user_login event logged');
   plausible('Log in to CAS');
@@ -56,14 +57,19 @@ window.log_plausible_contact_us = function () {
 };
 /* eslint-enable no-console */
 /* eslint-enable no-undef */
+/* eslint-enable func-names */
 
+/* eslint-disable no-restricted-globals */
+/* eslint-disable no-alert */
 window.confirmOrcidRemove = function confirmOrcidRemove(id) {
   const button = document.getElementById(id);
-  button.onclick = function(event) {
-    const remove = confirm("Are you sure you want to revoke Princeton access to your ORCiD profile?");
-    if(remove !== true) {
+  button.onclick = function confirmDialog(event) {
+    const remove = confirm('Are you sure you want to revoke Princeton access to your ORCiD profile?');
+    if (remove !== true) {
       // cancel the button click
       event.preventDefault();
     }
   };
-}
+};
+/* eslint-enable no-restricted-globals */
+/* eslint-enable no-alert */

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,7 +48,7 @@ class User < ApplicationRecord
 
   def revoke_active_tokens
     now = DateTime.now
-    tokens.where("expiration > ?", now).each do |token|
+    tokens.where("expiration > ?", now).find_each do |token|
       token.expiration = now
       token.save!
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,4 +45,12 @@ class User < ApplicationRecord
     valid_tokens = tokens.reject(&:expired?)
     valid_tokens.first
   end
+
+  def revoke_active_tokens
+    now = DateTime.now
+    tokens.where("expiration < ?", now) do |token|
+      token.expiration = now
+      token.save!
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,7 +48,7 @@ class User < ApplicationRecord
 
   def revoke_active_tokens
     now = DateTime.now
-    tokens.where("expiration < ?", now) do |token|
+    tokens.where("expiration > ?", now).each do |token|
       token.expiration = now
       token.save!
     end

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -10,4 +10,11 @@
   <p>
   Your token grants Princeton access to read and update your ORCID record until <%= user.valid_token.expiration.strftime('%m/%d/%Y') %>.
   </p>
+  <%= form_with method: :post, url: orcid_revoke_path(user) do |form| %>
+    <button id="remove-orcid-tokens" class="btn btn-danger">Revoke Authentication</button>
+  <% end %>
 <% end %>
+
+<script type="module">
+  confirmOrcidRemove("remove-orcid-tokens");
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,5 +27,6 @@ Rails.application.routes.draw do
     get "sign_in", to: "devise/sessions#new", as: :new_user_session
     get "sign_in", to: "users/omniauth_callbacks#passthru", as: :session
     get "sign_out", to: "devise/sessions#destroy", as: :destroy_user_session
+    post ":id/orcid_revoke", to: "users#orcid_revoke", as: :orcid_revoke
   end
 end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+namespace :users do
+  # Adds a fake token to emulate a linking to ORCiD within the application
+  task :fake_orcid_link, [:netid] => [:environment] do |_, args|
+    netid = args[:netid]
+    user = User.where(uid: netid).first
+    token_value = SecureRandom.hex
+    expiration = DateTime.now + 30
+    user_token = Token.new(user_id: user.id, token_type: "bearer", token: token_value, expiration:)
+    user_token.save!
+    puts "Added token #{token_value} to user #{netid}. Expiration: #{expiration}"
+  end
+end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 namespace :users do
-  # Adds a fake token to emulate a linking to ORCiD within the application
+  desc "Adds a fake token to a user to emulate linking to ORCiD"
   task :fake_orcid_link, [:netid] => [:environment] do |_, args|
     netid = args[:netid]
     user = User.where(uid: netid).first

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -123,4 +123,14 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe "#revoke_active_tokens" do
+    let(:user) { FactoryBot.create(:user_with_orcid_and_token) }
+    it "expires all valid tokes" do
+      expect(user.valid_token).to_not be nil
+      user.revoke_active_tokens
+      user.reload
+      expect(user.valid_token).to be nil
+    end
+  end
 end

--- a/spec/system/user_show_spec.rb
+++ b/spec/system/user_show_spec.rb
@@ -9,5 +9,16 @@ describe "user show screen", type: :system, js: true do
       visit "/users/#{user.id}"
       expect(page).to have_content("https://orcid.org/#{user.orcid}")
     end
+
+    it "it allows a user to revoke linking to ORCiD" do
+      login_as user
+      visit "/users/#{user.id}"
+      # user has linked their account to ORCiD
+      expect(page).to have_content("https://orcid.org/#{user.orcid}")
+      click_on "Revoke Authentication"
+      page.driver.browser.switch_to.alert.accept
+      # account is not linked anymore
+      expect(page).to have_content("Connect your ORCID iD")
+    end
   end
 end


### PR DESCRIPTION
Adds a button to allow a user to manually revoke ORCiD tokens. Works towards #143.

Notice that this implementation revokes the tokens as soon as the user clicks the button without checking with ORCiD if the token is still valid or not. I did it this way because it was simpler but that's also why I am not closing issue #143. I can add the API check to ORCiD for real in a separate PR if we still want it.

## New button
![Screenshot 2024-07-31 at 3 12 42 PM](https://github.com/user-attachments/assets/31226899-6891-4b6a-8289-a54490b6eb8b)

## Display after tokens have been revoked
![Screenshot 2024-07-31 at 3 17 52 PM](https://github.com/user-attachments/assets/6c956c81-39f6-44ee-af8d-719c24274ff1)
