### PR TITLE
changing the orcid id display language on the user show page

### DIFF
--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -8,7 +8,7 @@
 
 <% if user.valid_token %>
   <p>
-    ORCID iD, <%= user.valid_token %>, is connected to your NetID, <%= user.uid %>
+    Your ORCID iD is connected to your NetID, <%= user.uid %>
   </p>
   <p>
     Your token grants Princeton access to read and update your ORCID record until <%= user.valid_token.expiration.strftime('%m/%d/%Y') %>.


### PR DESCRIPTION
Changing "ORCID iD, $TOKEN, is connected to your NetID, $NETID" to "Your ORCID iD is connected to your NetID, $NETID" on the user page.



closes #243 