### PR TITLE
Allowing ORCID token check url to be configured

### DIFF
--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -27,7 +27,7 @@ class Token < ApplicationRecord
   # Checks is a token is still valid with ORCiD
   # A token can become invalid if the user revokes it within ORCiD
   def self.valid_in_orcid?(token, orcid)
-    url = "https://api.sandbox.orcid.org/v3.0/#{orcid}/record"
+    url = "#{Rails.application.config.orcid[:url]}/#{orcid}/record"
     headers = {
       "Accept" => "application/json",
       "Authorization" => "Bearer #{token}"

--- a/config/initializers/load_orcid.rb
+++ b/config/initializers/load_orcid.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+module OrcidPrinceton
+  class Application < Rails::Application
+    config.orcid = config_for(:orcid)
+  end
+end

--- a/config/orcid.yml
+++ b/config/orcid.yml
@@ -1,0 +1,14 @@
+sandbox: &sandbox
+  url: https://api.sandbox.orcid.org/v3.0
+
+development:
+  <<: *sandbox
+
+test:
+  <<: *sandbox
+
+staging:
+  <<: *sandbox
+
+production:
+  url: https://api.orcid.org/v3.0


### PR DESCRIPTION
fixes #240 

Deployed to production and staging, this PR worked well with a token that I enabled and then revoked on each machine.