### PR TITLE
Integrating rolify into the User model for administrators

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,3 +61,5 @@ group :test do
   gem "selenium-webdriver"
   gem "webmock"
 end
+
+gem "rolify", "~> 6.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -405,6 +405,7 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.3.9)
+    rolify (6.0.1)
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.0)
@@ -565,6 +566,7 @@ DEPENDENCIES
   rack (= 2.2.8.1)
   rails (~> 7.1.0)
   rails-controller-testing
+  rolify (~> 6.0)
   rspec-rails
   selenium-webdriver
   simplecov

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class Role < ApplicationRecord
+  has_many :users, through: :users_roles
+
+  belongs_to :resource,
+             polymorphic: true,
+             optional: true
+
+  validates :resource_type,
+            inclusion: { in: Rolify.resource_types },
+            allow_nil: true
+
+  scopify
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@
 require "devise"
 
 class User < ApplicationRecord
+  rolify
   devise :omniauthable, omniauth_providers: [:cas, :orcid]
   has_many :tokens, dependent: :destroy
 
@@ -56,6 +57,22 @@ class User < ApplicationRecord
         token.expiration = now
         token.save!
       end
+    end
+  end
+
+  def admin?
+    has_role?(:admin)
+  end
+
+  def self.create_admin(uid)
+    user = User.find_or_create_by(uid:)
+    user.add_role(:admin) unless user.admin?
+    user
+  end
+
+  def self.create_default_users
+    Rails.configuration.admins.each do |uid|
+      create_admin(uid)
     end
   end
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,7 +3,11 @@
   <div class="user-page-content">
   <h1 class="page-title">ORCID@Princeton</h1>
   <div class="welcome-section">
-      <h2>Welcome, <%= @user.display_name %></h2>
+      <% if @user.admin? %>
+        <h2>Welcome, <%= @user.display_name %> (Administrator)</h2>
+      <% else %>
+        <h2>Welcome, <%= @user.display_name %></h2>
+      <% end %>
 
       <!-- If the user doesn't have any tokens, prompt them to create one. -->
       <% if @user.tokens.empty? && orcid_available? %>

--- a/config/admins.yml
+++ b/config/admins.yml
@@ -1,0 +1,13 @@
+---
+production: &default
+  - neggink # Neggin Keshavarzian
+  - kl37 # Kate Lynch
+  - bs3097 # Bess Sadler
+  - cac9 # Carolyn Cole
+  - rl3667 # Robert-Anthony Lee-Faison
+  - jh6441 # Jaymee Hyppolite
+  - hc8719 # Hector Correa
+  - jrg5 # James Griffin
+staging: *default
+development: *default
+test: *default

--- a/config/initializers/load_admins.rb
+++ b/config/initializers/load_admins.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+module OrcidPrinceton
+  class Application < Rails::Application
+    config.admins = config_for(:admins)
+  end
+end

--- a/config/initializers/rolify.rb
+++ b/config/initializers/rolify.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+Rolify.configure do |config|
+  # By default ORM adapter is ActiveRecord. uncomment to use mongoid
+  # config.use_mongoid
+
+  # Dynamic shortcuts for User class (user.is_admin? like methods). Default is: false
+  # config.use_dynamic_shortcuts
+
+  # Configuration to remove roles from database once the last resource is removed. Default is: true
+  # config.remove_role_if_empty = false
+end

--- a/db/migrate/20250206195504_rolify_create_roles.rb
+++ b/db/migrate/20250206195504_rolify_create_roles.rb
@@ -1,0 +1,18 @@
+class RolifyCreateRoles < ActiveRecord::Migration[7.1]
+  def change
+    create_table(:roles) do |t|
+      t.string :name
+      t.references :resource, :polymorphic => true
+
+      t.timestamps
+    end
+
+    create_table(:users_roles, :id => false) do |t|
+      t.references :user
+      t.references :role
+    end
+    
+    add_index(:roles, [ :name, :resource_type, :resource_id ])
+    add_index(:users_roles, [ :user_id, :role_id ])
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_06_153247) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_06_195504) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "roles", force: :cascade do |t|
+    t.string "name"
+    t.string "resource_type"
+    t.bigint "resource_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id"
+    t.index ["resource_type", "resource_id"], name: "index_roles_on_resource"
+  end
 
   create_table "tokens", force: :cascade do |t|
     t.string "token_type"
@@ -37,6 +47,14 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_06_153247) do
     t.string "university_id"
     t.index ["provider"], name: "index_users_on_provider"
     t.index ["uid"], name: "index_users_on_uid", unique: true
+  end
+
+  create_table "users_roles", id: false, force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "role_id"
+    t.index ["role_id"], name: "index_users_roles_on_role_id"
+    t.index ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id"
+    t.index ["user_id"], name: "index_users_roles_on_user_id"
   end
 
 end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -18,4 +18,21 @@ namespace :users do
     valid = Token.valid_in_orcid?(token, orcid)
     puts "Token #{token} is valid for ORCiD #{orcid}: #{valid}"
   end
+
+  desc "Creates user records for the users defined as the default administrators"
+  task setup_default: :environment do
+    User.create_default_users
+  end
+
+  desc "Updates users to make sure the admin role is set"
+  task update_roles: :environment do
+    User.create_default_users
+  end
+
+  desc "Deletes existing user data and recreates the defaults."
+  task reset_default: :environment do
+    Role.delete_all
+    User.delete_all
+    User.create_default_users
+  end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     given_name { FFaker::Name.first_name }
     family_name { FFaker::Name.last_name }
     display_name { "#{given_name} #{family_name}" }
+    roles { [] }
 
     factory :user_with_orcid do
       # Follow the rules defined in https://support.orcid.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier
@@ -33,6 +34,12 @@ FactoryBot.define do
         # Pad the front of the number with zeros until it is 16 digits long
         # Format the ORCID identifier with dashes between each 4 digits
         number_array.join.rjust(16, "0").chars.each_slice(4).map(&:join).join("-")
+      end
+
+      factory :admin do
+        after(:create) do |user|
+          user.add_role(:admin)
+        end
       end
 
       factory :user_with_orcid_and_token do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -189,4 +189,34 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe "#admin?" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:admin) { FactoryBot.create(:admin) }
+
+    it "determines whether or not a User is an admin user" do
+      expect(user.admin?).to be false
+      expect(admin.admin?).to be true
+    end
+  end
+
+  describe ".create_default_users" do
+    let(:users) { described_class.all }
+
+    before do
+    end
+
+    it "creates configured User models with the necessary Roles" do
+      expect(users).to be_empty
+      described_class.create_default_users
+      expect(users).not_to be_empty
+
+      models = users.to_a
+      admins = models.select(&:admin?)
+      expect(admins.length).to eq(8)
+
+      non_admins = models.reject(&:admin?)
+      expect(non_admins).to be_empty
+    end
+  end
 end

--- a/spec/system/ux_flow_spec.rb
+++ b/spec/system/ux_flow_spec.rb
@@ -86,4 +86,17 @@ describe "user experience from start to finish", type: :system, js: true do
         .according_to(:wcag2a, :wcag2aa, :wcag21a, :wcag21aa, :section508, :"best-practice")
     end
   end
+
+  context "an administrator user" do
+    let(:user) { FactoryBot.create(:admin) }
+
+    it "walks the user through the process of entering an ORCID and creating a token" do
+      login_as(user)
+
+      visit "/"
+      click_on "Profile"
+
+      expect(page).to have_content "Welcome, #{user.display_name} (Administrator)"
+    end
+  end
 end


### PR DESCRIPTION
Resolves #312 by addressing the following:

- Integrating rolify into the User model
- Implementing support for assigning the admin role from a YAML configuration file
- Implementing a Rake task for creating admin. user models
- Ensuring that admin users see a welcome message indicating that they are administrators