### PR TITLE
Fixed LUX header and updated spec

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,7 +4,7 @@
     <lux-library-header app-name="ORCID@Princeton" abbr-name="ORCID@Princeton" theme="dark">
       <lux-menu-bar type="main-menu" :menu-items="[
         {name: 'Home', component: 'Home', href: '/'},
-          {name: '<%= current_user.display_name %>', component: 'Account', href: '/account/', children: [
+          {name: '<%= current_user.uid %>', component: 'Account', href: '/account/', children: [
             {name: 'Profile', component: 'Feedback', href: '<%= user_path(current_user )%> '},
             {name: 'ORCID Report', component: 'Feedback', href: '<%= orcid_report_path%> '},
             {name: 'Logout', component: 'Logout', href: '<%= main_app.destroy_user_session_path %> '}
@@ -16,7 +16,7 @@
   <lux-library-header app-name="ORCID@Princeton" abbr-name="ORCID@Princeton" theme="dark">
     <lux-menu-bar type="main-menu" :menu-items="[
       {name: 'Home', component: 'Home', href: '/'},
-        {name: '<%= current_user.display_name %>', component: 'Account', href: '/account/', children: [
+        {name: '<%= current_user.uid %>', component: 'Account', href: '/account/', children: [
           {name: 'Profile', component: 'Feedback', href: '<%= user_path(current_user )%> '},
           {name: 'Logout', component: 'Logout', href: '<%= main_app.destroy_user_session_path %> '}
         ]}

--- a/spec/system/ux_flow_spec.rb
+++ b/spec/system/ux_flow_spec.rb
@@ -19,9 +19,9 @@ describe "user experience from start to finish", type: :system, js: true do
       # The page should be accessible.
       expect(page).to be_axe_clean
         .according_to(:wcag2a, :wcag2aa, :wcag21a, :wcag21aa, :section508, :"best-practice")
-      expect(page).to have_content(user.display_name)
+      expect(page).to have_content(user.uid)
       # Expand the user menu dropdown
-      click_on user.display_name.to_s
+      click_on user.uid.to_s
       click_on "Profile"
 
       # The user is redirected to the user page after logging in.


### PR DESCRIPTION
Closes #386 

The test intermittently failing exposes a bug in the code.  The LUX menu method used to define menu items does not support apostrophes, so whenever an apostrophe appears in a name, the user menu bar does not render for logged-in users anywhere.

Looking at the [ORCID@Princeton](https://docs.google.com/presentation/d/1c9RSNP57UNW0SvTnE-2cSzqkpYEx1TkLfnzndOLksG8/edit#slide=id.g2ee741334bb_5_0) wireframes, it looks like we are in fact supposed to be using net IDs, not display names, for the menu labels:

## Wireframes 
![Screenshot 2025-03-05 at 4 12 58 PM](https://github.com/user-attachments/assets/1fb8d87f-fddb-4072-bb0c-df62a5b944a9)

Changing the template to match the wireframes and refactoring the test to match removes this bug and fixes the flapping tests.

## Passing with the specified seed:
![Screenshot 2025-03-05 at 3 29 24 PM](https://github.com/user-attachments/assets/b3ad1124-ed0a-4be7-ac3d-56de0908f9ec)
![Screenshot 2025-03-05 at 3 29 34 PM](https://github.com/user-attachments/assets/d5a8b761-f51d-420c-977d-6f1f818e01bd)

## Passing with the specified name: 
![Screenshot 2025-03-05 at 3 29 44 PM](https://github.com/user-attachments/assets/644a4d85-910e-4bf4-b87c-bd688a32926a)
![Screenshot 2025-03-05 at 3 30 14 PM](https://github.com/user-attachments/assets/2765b6ac-680f-4e66-b9dc-830d7ba2541d)

